### PR TITLE
use win22 and add input to run release as dry-run, use win22 and add input to run release as dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
 name: "Release"
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Add --dry-run flag to npm publish'
+        default: true
+        type: boolean
 
 jobs:
   prebuild:
@@ -71,7 +76,7 @@ jobs:
             os: ['self-hosted', 'macOS', 'ARM64']
 
           - name: windows-x86_64
-            os: windows-2019
+            os: windows-2022
 
     steps: 
     - uses: actions/checkout@v1
@@ -143,5 +148,9 @@ jobs:
       - run: yarn lint
       - run: yarn build
       - run: yarn test
+      - name: Simulate Publishing to NPM
+        if:  ${{ inputs.dryrun }}
+        run: npm publish --access public --dry-run
       - name: Publish to NPM
+        if:  ${{ !inputs.dryrun }}
         run: npm publish --access public

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { Socket } from 'net';
 import { ArgvOrCommandLine } from './types';
 import { fork } from 'child_process';
+import { ptyPath } from './prebuild-file-path';
 
 let conptyNative: IConptyNative;
 let winptyNative: IWinptyNative;
@@ -60,7 +61,7 @@ export class WindowsPtyAgent {
     if (this._useConpty) {
       if (!conptyNative) {
         try {
-          conptyNative = require('../build/Release/conpty.node');
+          conptyNative = require(ptyPath || '../build/Release/conpty.node');
         } catch (outerError) {
           try {
             conptyNative = require('../build/Debug/conpty.node');


### PR DESCRIPTION
- feat: use win22 and add input to run release as dry-run
- fix: use prebuilt on windows too, if using pty
