### PR TITLE
feat: add support for Node.js 18 and 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,51 @@ jobs:
             DOCKERFILE: Dockerfile.alpine
             QEMU_ARCH: x86_64
 
+          - name: alpine-x86_64
+            os: ubuntu-latest
+            BASE_IMAGE: library/node:18-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: x86_64
+
+          - name: alpine-x86_64
+            os: ubuntu-latest
+            BASE_IMAGE: library/node:20-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: x86_64
+
           - name: alpine-arm32v6
             os: ubuntu-latest
             BASE_IMAGE: arm32v6/node:16-alpine
             DOCKERFILE: Dockerfile.alpine
             QEMU_ARCH: arm
 
+          - name: alpine-arm32v6
+            os: ubuntu-latest
+            BASE_IMAGE: arm32v6/node:18-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: arm
+
+          - name: alpine-arm32v6
+            os: ubuntu-latest
+            BASE_IMAGE: arm32v6/node:20-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: arm
+
           - name: alpine-arm64v8
             os: ubuntu-latest
             BASE_IMAGE: arm64v8/node:16-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: aarch64
+
+          - name: alpine-arm64v8
+            os: ubuntu-latest
+            BASE_IMAGE: arm64v8/node:18-alpine
+            DOCKERFILE: Dockerfile.alpine
+            QEMU_ARCH: aarch64
+
+          - name: alpine-arm64v8
+            os: ubuntu-latest
+            BASE_IMAGE: arm64v8/node:20-alpine
             DOCKERFILE: Dockerfile.alpine
             QEMU_ARCH: aarch64
 


### PR DESCRIPTION
## Why

Because Node.js 16 won't be maintained soon

[Node.js release calendar](https://nodejs.dev/en/about/releases/)

Also, my team faced a problem when our Github action runners don't have `g++` installed so we can't compile this package. It must be pre-compiled if we want to use Terraform CDK with Node.js 20


## What was done

I just added Node 18 and 20 Docker images to Github workflow configuration. 
I don't know if something more is required to support those Node.js versions

