### PR TITLE
chore: update & pin actions used in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
             os: windows-2022
 
     steps: 
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
       with:
         node-version: 16.x
 
@@ -103,7 +103,7 @@ jobs:
 
     - name: macOS - Setup Python
       if: runner.os == 'macOS'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.11'
         architecture: x64
@@ -122,7 +122,7 @@ jobs:
         yarn install --ignore-scripts
         node .prebuild/buildify-windows.js
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: prebuilds
         path: prebuilds
@@ -132,14 +132,14 @@ jobs:
     needs:
       - prebuild
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v3.6.0
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version: 19.x
           registry-url: "https://registry.npmjs.org" # required to use auth
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: prebuilds
           path: prebuilds


### PR DESCRIPTION
In preparation for us needing to do some work in this codebase, I noticed that we're using some very old versions of              GitHub Actions, and the last build 8 months ago already had these warnings:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This updates them to the latest versions supported by HashiCorp's TSCCR (using `tsccr-helper -pin-all-workflows .`)